### PR TITLE
fix subidx to compute motion correction template from a movie slice

### DIFF
--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -99,7 +99,7 @@ class MotionCorrect(object):
                  strides=(96, 96), overlaps=(32, 32), splits_els=14, num_splits_to_process_els=None,
                  upsample_factor_grid=4, max_deviation_rigid=3, shifts_opencv=True, nonneg_movie=True, gSig_filt=None,
                  use_cuda=False, border_nan=True, pw_rigid=False, num_frames_split=80, var_name_hdf5='mov',is3D=False,
-                 indices=(slice(None), slice(None))):
+                 indices=(slice(None), slice(None)), subidx=slice(None, None, 1)):
         """
         Constructor class for motion correction operations
 
@@ -213,6 +213,7 @@ class MotionCorrect(object):
         self.var_name_hdf5 = var_name_hdf5
         self.is3D = bool(is3D)
         self.indices = indices
+        self.subidx = subidx
         if self.use_cuda and not HAS_CUDA:
             logging.debug("pycuda is unavailable. Falling back to default FFT.")
 
@@ -317,7 +318,8 @@ class MotionCorrect(object):
                 border_nan=self.border_nan,
                 var_name_hdf5=self.var_name_hdf5,
                 is3D=self.is3D,
-                indices=self.indices)
+                indices=self.indices,
+                subidx=self.subidx)
             if template is None:
                 self.total_template_rig = _total_template_rig
 
@@ -2830,7 +2832,9 @@ def motion_correct_batch_rigid(fname, max_shifts, dview=None, splits=56, num_spl
         Exception 'The movie contains nans. Nans are not allowed!'
 
     """
-
+    if subidx.start is not None:
+        print(f"Computing template from frames {subidx}.")
+    
     dims, T = cm.source_extraction.cnmf.utilities.get_file_size(fname, var_name_hdf5=var_name_hdf5)
     Ts = np.arange(T)[subidx].shape[0]
     step = Ts // 10 if is3D else Ts // 50
@@ -2863,6 +2867,8 @@ def motion_correct_batch_rigid(fname, max_shifts, dview=None, splits=56, num_spl
                 m = m.copy()
             template = caiman.motion_correction.bin_median(
                     m.motion_correct(max_shifts[1], max_shifts[0], template=None)[0])
+    else:
+        template = high_pass_filter_space(template, gSig_filt)
 
     new_templ = template
     if add_to_movie is None:
@@ -2892,10 +2898,10 @@ def motion_correct_batch_rigid(fname, max_shifts, dview=None, splits=56, num_spl
 
         fname_tot_rig, res_rig = motion_correction_piecewise(fname, splits, strides=None, overlaps=None,
                                                              add_to_movie=add_to_movie, template=old_templ, max_shifts=max_shifts, max_deviation_rigid=0,
-                                                             dview=dview, save_movie=save_movie, base_name=base_name, subidx = subidx,
+                                                             dview=dview, save_movie=save_movie, base_name=base_name,
                                                              num_splits=num_splits_to_process, shifts_opencv=shifts_opencv, nonneg_movie=nonneg_movie, gSig_filt=gSig_filt,
                                                              use_cuda=use_cuda, border_nan=border_nan, var_name_hdf5=var_name_hdf5, is3D=is3D,
-                                                             indices=indices)
+                                                             indices=indices, subidx=None)
         if is3D:
             new_templ = np.nanmedian(np.stack([r[-1] for r in res_rig]), 0)           
         else:

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 channels:
 - conda-forge
 dependencies:
-- python >=3.10
+- python =3.9
 - bokeh
 - coverage
 - cython


### PR DESCRIPTION
When motion correcting a series of recordings (i.e., concatenated movies), in some cases there is a shift between movies' FOVs, and the default template/reference frame computed by averaging 50 frames uniformly sampled across the series is spoiled. Concretely, it's like averaging (for two movies of equal duration) half frames with a "resting position" (x, y) and half frames with a shifted resting position (x + a, y + b), resulting in a blurry / dual state template and eventually to failed motion correction.

One solution is to compute the template from one movie only, and that's what the argument "subidx" is meant to do: define a movie slice from which to sample the 50 frames. Only, 1) this argument wasn't taken into account, and 2) it also affected the output movie (only output the chosen slice), making it useless.

This PR fixes "subidx", and allows for a successful template/reference frame computation (using the exact same sampling and spatial filtering steps as built-in) from one movie only, critically enabling the successful use of NoRMCorre on concatenated movies.